### PR TITLE
Media Links absolut verlinken

### DIFF
--- a/files/rex_markitup.js
+++ b/files/rex_markitup.js
@@ -11,7 +11,7 @@
  var insertFileLink = function(file) {
    jQuery.markItUp({
      openWith:'"',
-     closeWith:'":'+file,
+     closeWith:'":/'+file,
      placeHolder:file,
      file:file,
     className:'popup-linkmedia'


### PR DESCRIPTION
Ansonsten werden die Dateien falsch verlinkt.
